### PR TITLE
24 glossary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,8 @@ Glossary of terms
 
    * - Term
      - Description
+   * - GNPS
+     - Knowledge base for sharing of mass spectrometry data (`link <https://gnps.ucsd.edu/ProteoSAFe/static/gnps-splash.jsp>`__).
    * - InChI / :code:`INCHI`
      - InChI is short for International Chemical Identifier. InChIs are useful
        in retrieving information associated with a certain molecule from a
@@ -80,8 +82,6 @@ Glossary of terms
      - An indentifier for molecules. For example, the InChI key for carbon
        dioxide is :code:`InChIKey=CURLTUGMZLYLDI-UHFFFAOYSA-N` (yes, it
        includes the substring :code:`InChIKey=`).
-   * - GNPS
-     - Knowledge base for sharing of mass spectrometry data. `link <https://gnps.ucsd.edu/ProteoSAFe/static/gnps-splash.jsp>`__
    * - SMILES
      - A line notation for describing the structure of chemical species using
        short ASCII strings. For example, water is encoded as :code:`O[H]O`,

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,9 @@ Glossary of terms
      - An indentifier for molecules. For example, the InChI key for carbon
        dioxide is :code:`InChIKey=CURLTUGMZLYLDI-UHFFFAOYSA-N` (yes, it
        includes the substring :code:`InChIKey=`).
+   * - MGF File / Mascot Generic Format
+     - A plan ASCII file format to store peak list data from a mass spectrometry experiment. Links: `matrixscience.com <http://www.matrixscience.com/help/data_file_help.html#GEN>`__, 
+       `fiehnlab.ucdavis.edu <https://fiehnlab.ucdavis.edu/projects/lipidblast/mgf-files>`__.
    * - SMILES
      - A line notation for describing the structure of chemical species using
        short ASCII strings. For example, water is encoded as :code:`O[H]O`,

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+################################################################################
+matchms
+################################################################################
+
 .. list-table::
    :widths: 25 25
    :header-rows: 1
@@ -41,12 +45,7 @@ https://badgen.net/ to see which other badges are available.)
    :target: https://bestpractices.coreinfrastructure.org/projects/3792
    :alt: CII Best Practices Badge
 
-################################################################################
-matchms
-################################################################################
-
 Vector representation and similarity measure for mass spectrometry data
-
 
 The project setup is documented in `a separate document <project_setup.rst>`_.
 Feel free to remove this document (and/or the link to this document) if you

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,10 @@ Glossary of terms
 
    * - Term
      - Description
+   * - adduct / addition product
+     - During ionization in a mass spectrometer, the molecules of the injected compound break apart 
+       into fragments. When fragments combine into a new compound, this is known as an addition 
+       product, or adduct.  `Wikipedia <https://en.wikipedia.org/wiki/Adduct>`__
    * - GNPS
      - Knowledge base for sharing of mass spectrometry data (`link <https://gnps.ucsd.edu/ProteoSAFe/static/gnps-splash.jsp>`__).
    * - InChI / :code:`INCHI`

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,8 @@
    * - \5. Checklist
      - |CII Best Practices Badge|
 
-(Customize these badges with your own links, and check https://shields.io/ or https://badgen.net/ to see which other badges are available.)
+(Customize these badges with your own links, and check https://shields.io/ or
+https://badgen.net/ to see which other badges are available.)
 
 .. |GitHub Badge| image:: https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue
    :target: https://github.com/matchms/matchms
@@ -47,10 +48,50 @@ matchms
 Vector representation and similarity measure for mass spectrometry data
 
 
-The project setup is documented in `a separate document <project_setup.rst>`_. Feel free to remove this document (and/or the link to this document) if you don't need it.
+The project setup is documented in `a separate document <project_setup.rst>`_.
+Feel free to remove this document (and/or the link to this document) if you
+don't need it.
+
+***********************
+Documentation for users
+***********************
+
+Install matchms from PyPI with
+
+.. code-block:: console
+
+  pip install --user matchms
 
 Installation
-------------
+============
+
+Glossary of terms
+=================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Term
+     - Description
+   * - InChI / :code:`INCHI`
+     - InChI is short for International Chemical Identifier. InChIs are useful
+       in retrieving information associated with a certain molecule from a
+       database.
+   * - InChIKey / InChI key / :code:`INCHIKEY`
+     - An indentifier for molecules. For example, the InChI key for carbon
+       dioxide is :code:`InChIKey=CURLTUGMZLYLDI-UHFFFAOYSA-N` (yes, it
+       includes the substring :code:`InChIKey=`).
+   * - GNPS
+     - Knowledge base for sharing of mass spectrometry data. `link <https://gnps.ucsd.edu/ProteoSAFe/static/gnps-splash.jsp>`__
+   * - SMILES
+     - A line notation for describing the structure of chemical species using
+       short ASCII strings. For example, water is encoded as :code:`O[H]O`,
+       carbon dioxide is encoded as :code:`O=C=O`, etc. SMILES-encoded species may be converted to InChIKey `using a resolver like this one <https://cactus.nci.nih.gov/chemical/structure>`__. The Wikipedia entry for SMILES is `here <https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system>`__.
+
+
+****************************
+Documentation for developers
+****************************
 
 To install matchms, do:
 
@@ -67,20 +108,18 @@ Run tests (including coverage) with:
 
   python setup.py test
 
-
-Documentation
-*************
-
-.. _README:
-
-Include a link to your project's full documentation here.
-
 Contributing
-************
+============
 
 If you want to contribute to the development of matchms,
 have a look at the `contribution guidelines <CONTRIBUTING.rst>`_.
 
+*****************************
+Documentation for maintainers
+*****************************
+
+
+*******
 License
 *******
 
@@ -99,8 +138,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-
+*******
 Credits
 *******
 
-This package was created with `Cookiecutter <https://github.com/audreyr/cookiecutter>`_ and the `NLeSC/python-template <https://github.com/NLeSC/python-template>`_.
+This package was created with `Cookiecutter
+<https://github.com/audreyr/cookiecutter>`_ and the `NLeSC/python-template
+<https://github.com/NLeSC/python-template>`_.

--- a/README.rst
+++ b/README.rst
@@ -55,14 +55,14 @@ don't need it.
 Documentation for users
 ***********************
 
+Installation
+============
+
 Install matchms from PyPI with
 
 .. code-block:: console
 
   pip install --user matchms
-
-Installation
-============
 
 Glossary of terms
 =================
@@ -91,6 +91,9 @@ Glossary of terms
 ****************************
 Documentation for developers
 ****************************
+
+Installation
+============
 
 To install matchms, do:
 


### PR DESCRIPTION
This PR adds a minimal glossary of terms. 

I moved some sections around and added a differentiation between documentation for users, developers and maintainers (perhaps the user documentation will be split off at a later stage and be replace with a link to readthedocs).

I also refactored the document a bit to comply with sphinx's style guide (https://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html)
