### PR TITLE
added sonarcloud include/exclude patterns

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,3 @@
+sonar.sources=matchms/**/*.py
+sonar.exclusions=matchms/old/,matchms/similarity/spec2vec/helper_functions.py,matchms/similarity/spec2vec/ms_functions.py,matchms/similarity/spec2vec/ms_library_search.py,matchms/similarity/spec2vec/ms_similarity_classical.py,matchms/similarity/spec2vec/similarity_measure.py
+


### PR DESCRIPTION
Note this is branched off of 14-conda, and asks to be merged back into it.

The PR adds inclusion/exclusion patterns for sonarcloud in order to avoid the errors about code duplication. It seems neither this push nor making the PR triggered a sonarcloud check, so not sure if I can see if it works.