### PR TITLE
Cleaned up test for clean_inchis

### DIFF
--- a/matchms/filtering/clean_inchis.py
+++ b/matchms/filtering/clean_inchis.py
@@ -25,7 +25,8 @@ def clean_inchis(spectrum_in, rescue_smiles=True):
                 # Try to 'rescue' given inchi which are actually smiles!
                 assumed_smile = inchi.split('InChI=')[-1].replace('"', '')
                 inchi = mol_converter(assumed_smile, "smi", "inchi")
-                print('new inchi:', inchi, assumed_smile)
+                print("New inchi:", inchi.replace('\n', ''))
+                print("Derived from assumed_smile:", assumed_smile)
 
         inchi = inchi.strip().split('InChI=')[-1]
         if inchi.endswith('"'):

--- a/tests/test_clean_inchis.py
+++ b/tests/test_clean_inchis.py
@@ -1,4 +1,3 @@
-import os
 import numpy as np
 from matchms import Spectrum
 from matchms.filtering import clean_inchis
@@ -8,8 +7,8 @@ def test_clean_inchis_misplaced_smiles():
     """Test if misplaced smiles are corrected.
     """
     spectrum_in = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
-                          intensities=np.array([0, 1, 10, 100], dtype='float'),
-                          metadata={"inchi": "C1CCCCC1"})
+                           intensities=np.array([0, 1, 10, 100], dtype='float'),
+                           metadata={"inchi": "C1CCCCC1"})
 
     spectrum = clean_inchis(spectrum_in)
     assert spectrum.get("inchi") == '"InChI=1S/C6H12/c1-2-4-6-5-3-1/h1-6H2"', "Expected different InChI"
@@ -19,12 +18,12 @@ def test_clean_inchis_harmonize_strings():
     """Test if inchi strings are made consistent in style.
     """
     spectrum_in1 = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
-                          intensities=np.array([0, 1, 10, 100], dtype='float'),
-                          metadata={"inchi": 'InChI=1S/C6H12'})
+                            intensities=np.array([0, 1, 10, 100], dtype='float'),
+                            metadata={"inchi": 'InChI=1S/C6H12'})
 
     spectrum_in2 = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
-                          intensities=np.array([0, 1, 10, 100], dtype='float'),
-                          metadata={"inchi": '1S/C6H12'})
+                            intensities=np.array([0, 1, 10, 100], dtype='float'),
+                            metadata={"inchi": '1S/C6H12'})
 
     spectrum1 = clean_inchis(spectrum_in1)
     spectrum2 = clean_inchis(spectrum_in2)

--- a/tests/test_clean_inchis.py
+++ b/tests/test_clean_inchis.py
@@ -6,8 +6,8 @@ from matchms.filtering import clean_inchis
 def test_clean_inchis_misplaced_smiles():
     """Test if misplaced smiles are corrected.
     """
-    spectrum_in = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
-                           intensities=np.array([0, 1, 10, 100], dtype='float'),
+    spectrum_in = Spectrum(mz=np.array([], dtype='float'),
+                           intensities=np.array([], dtype='float'),
                            metadata={"inchi": "C1CCCCC1"})
 
     spectrum = clean_inchis(spectrum_in)
@@ -17,12 +17,12 @@ def test_clean_inchis_misplaced_smiles():
 def test_clean_inchis_harmonize_strings():
     """Test if inchi strings are made consistent in style.
     """
-    spectrum_in1 = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
-                            intensities=np.array([0, 1, 10, 100], dtype='float'),
+    spectrum_in1 = Spectrum(mz=np.array([], dtype='float'),
+                            intensities=np.array([], dtype='float'),
                             metadata={"inchi": 'InChI=1S/C6H12'})
 
-    spectrum_in2 = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
-                            intensities=np.array([0, 1, 10, 100], dtype='float'),
+    spectrum_in2 = Spectrum(mz=np.array([], dtype='float'),
+                            intensities=np.array([], dtype='float'),
                             metadata={"inchi": '1S/C6H12'})
 
     spectrum1 = clean_inchis(spectrum_in1)

--- a/tests/test_clean_inchis.py
+++ b/tests/test_clean_inchis.py
@@ -1,33 +1,37 @@
 import os
-
-
-from matchms.importing import load_from_mgf
+import numpy as np
+from matchms import Spectrum
 from matchms.filtering import clean_inchis
 
 
-def test_clean_inchis():
-    """Draft for test.
+def test_clean_inchis_misplaced_smiles():
+    """Test if misplaced smiles are corrected.
     """
-    module_root = os.path.join(os.path.dirname(__file__), '..')
+    spectrum_in = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
+                          intensities=np.array([0, 1, 10, 100], dtype='float'),
+                          metadata={"inchi": "C1CCCCC1"})
 
-    # Loading
-    references_file = os.path.join(module_root, 'tests', 'testdata.mgf')
+    spectrum = clean_inchis(spectrum_in)
+    assert spectrum.get("inchi") == '"InChI=1S/C6H12/c1-2-4-6-5-3-1/h1-6H2"', "Expected different InChI"
 
-    reference_spectrums_raw = load_from_mgf(references_file)
 
-    reference_spectrums = [clean_inchis(s) for s in reference_spectrums_raw]
+def test_clean_inchis_harmonize_strings():
+    """Test if inchi strings are made consistent in style.
+    """
+    spectrum_in1 = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
+                          intensities=np.array([0, 1, 10, 100], dtype='float'),
+                          metadata={"inchi": 'InChI=1S/C6H12'})
 
-    query_spectrum_raw = reference_spectrums_raw[0]
+    spectrum_in2 = Spectrum(mz=np.array([10, 20, 30, 40], dtype='float'),
+                          intensities=np.array([0, 1, 10, 100], dtype='float'),
+                          metadata={"inchi": '1S/C6H12'})
 
-    query_spectrum = clean_inchis(query_spectrum_raw)
-
-    assert query_spectrum_raw.get("inchi").startswith('InChI='), 'expected different InChI'
-    assert query_spectrum.get("inchi").startswith('"InChI='), 'InChI style not as expected.'
-    original_inchi = reference_spectrums_raw[2].get("inchi")
-    assert original_inchi.startswith('"InChI=CCCCCCCCCCCCCCCC(=O)'), "expected misplaced smiles"
-    modified_inchi = reference_spectrums[2].get("inchi")
-    assert modified_inchi.startswith('"InChI=1S/C24H50NO7P/'), "inchi was not converted correctly"
+    spectrum1 = clean_inchis(spectrum_in1)
+    spectrum2 = clean_inchis(spectrum_in2)
+    assert spectrum1.get("inchi").startswith('"InChI='), "InChI style not as expected"
+    assert spectrum2.get("inchi").startswith('"InChI='), "InChI style not as expected"
 
 
 if __name__ == '__main__':
-    test_clean_inchis()
+    test_clean_inchis_misplaced_smiles()
+    test_clean_inchis_harmonize_strings()

--- a/tests/test_clean_inchis.py
+++ b/tests/test_clean_inchis.py
@@ -28,7 +28,7 @@ def test_clean_inchis_harmonize_strings():
     spectrum1 = clean_inchis(spectrum_in1)
     spectrum2 = clean_inchis(spectrum_in2)
     assert spectrum1.get("inchi").startswith('"InChI='), "InChI style not as expected"
-    assert spectrum2.get("inchi").startswith('"InChI='), "InChI style not as expected"
+    assert spectrum1 == spectrum2, 'after cleaning both spectra should be equal'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As suggested by @jspaaks in #101 I removed the loading of the mgf file and replaced it by synthetic spectra.
(I also did a minor change to the print output of the clean_inchis function)

This was the last unit test loading the mgf file. So this PR should close #99 and #101.