### PR TITLE
Add function to save spectrum to mgf file

### DIFF
--- a/matchms/exporting/__init__.py
+++ b/matchms/exporting/__init__.py
@@ -1,4 +1,4 @@
-
 from .save import save
+from .save_as_mgf import save_as_mgf
 
-__all__ = ["save"]
+__all__ = ["save", "save_as_mgf"]

--- a/matchms/exporting/__init__.py
+++ b/matchms/exporting/__init__.py
@@ -1,4 +1,3 @@
-from .save import save
 from .save_as_mgf import save_as_mgf
 
-__all__ = ["save", "save_as_mgf"]
+__all__ = ["save_as_mgf"]

--- a/matchms/exporting/save.py
+++ b/matchms/exporting/save.py
@@ -1,2 +1,0 @@
-def save():
-    """save function"""

--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -1,23 +1,23 @@
 import pyteomics.mgf as py_mgf
 
 
-def save_as_mgf(spectra, filename):
-    """Save spectra as mgf file.
+def save_as_mgf(spectrums, filename):
+    """Save spectrum(s) as mgf file.
 
     Args:
     ----
-    spectra: list of Spectrum() objects, Spectrum() object
+    spectrums: list of Spectrum() objects, Spectrum() object
         Expected input are match.Spectrum.Spectrum() objects.
     filename: str
-        Provide filename to save spectra.
+        Provide filename to save spectrum(s).
     """
-    if not isinstance(spectra, list):
+    if not isinstance(spectrums, list):
         # Assume that input was single Spectrum
-        spectra = [spectra]
+        spectrums = [spectrums]
 
     # Convert matchms.Spectrum() into dictionaries for pyteomics
     spectrum_dicts = []
-    for spectrum in spectra:
+    for spectrum in spectrums:
         spectrum_dict = {"m/z array": spectrum.mz,
                          "intensity array": spectrum.intensities,
                          "params": spectrum.metadata}

--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -1,0 +1,26 @@
+import pyteomics.mgf as py_mgf
+
+
+def save_as_mgf(spectra, filename):
+    """Save spectra as mgf file.
+
+    Args:
+    ----
+    spectra: list of Spectrum() objects, Spectrum() object
+        Expected input are match.Spectrum.Spectrum() objects.
+    filename: str
+        Provide filename to save spectra.
+    """
+    if not isinstance(spectra, list):
+        # Assume that input was single Spectrum
+        spectra = [spectra]
+
+    # Convert matchms.Spectrum() into dictionaries for pyteomics
+    spectrum_dicts = []
+    for spectrum in spectra:
+        spectrum_dict = {"m/z array": spectrum.mz,
+                         "intensity array": spectrum.intensities,
+                         "params": spectrum.metadata}
+        spectrum_dicts.append(spectrum_dict)
+
+    py_mgf.write(spectrum_dicts, filename)

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -4,7 +4,7 @@ from matchms import Spectrum
 from matchms.exporting import save_as_mgf
 
 
-def test_save_as_mgf_single_spectrum():
+def test_save_as_mgf_single_spectrum(tmpdir):
     """Test saving spectrum to .mgf file"""
     spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
                         intensities=np.array([10, 10, 500], dtype="float"),
@@ -13,11 +13,12 @@ def test_save_as_mgf_single_spectrum():
                                   "pepmass": (100, 10.0),
                                   "test_field": 'test'})
     # Write to test file
-    save_as_mgf(spectrum, 'test.mgf')
-    assert os.path.isfile('test.mgf')
+    file = tmpdir.join('test.mgf')
+    save_as_mgf(spectrum, file)
+    assert os.path.isfile(file)
 
     # Test if content of mgf file is correct
-    with open('test.mgf', 'r') as f:
+    with open(file, 'r') as f:
         mgf_content = f.readlines()
     assert mgf_content[0] == 'BEGIN IONS\n'
     assert mgf_content[2] == 'CHARGE=1-\n'
@@ -51,5 +52,5 @@ def test_save_as_mgf_spectrum_list():
 
 
 if __name__ == "__main__":
-    test_save_as_mgf_single_spectrum()
+    test_save_as_mgf_single_spectrum(tmpdir)
     test_save_as_mgf_spectrum_list()

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -1,0 +1,55 @@
+import os
+import numpy as np
+from matchms import Spectrum
+from matchms.exporting import save_as_mgf
+
+
+def test_save_as_mgf_single_spectrum():
+    """Test saving spectrum to .mgf file"""
+    spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
+                        intensities=np.array([10, 10, 500], dtype="float"),
+                        metadata={"charge": -1,
+                                  "inchi": '"InChI=1S/C6H12"',
+                                  "pepmass": (100, 10.0),
+                                  "test_field": 'test'})
+    # Write to test file
+    save_as_mgf(spectrum, 'test.mgf')
+    assert os.path.isfile('test.mgf')
+
+    # Test if content of mgf file is correct
+    with open('test.mgf', 'r') as f:
+        mgf_content = f.readlines()
+    assert mgf_content[0] == 'BEGIN IONS\n'
+    assert mgf_content[2] == 'CHARGE=1-\n'
+    assert mgf_content[4] == 'TEST_FIELD=test\n'
+    assert mgf_content[7].split(" ")[0] == '300.0'
+    # Remove testfile again
+    os.remove('test.mgf')
+
+
+def test_save_as_mgf_spectrum_list():
+    """Test saving spectrum list to .mgf file"""
+    spectrum1 = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
+                        intensities=np.array([10, 10, 500], dtype="float"),
+                        metadata={"test_field": 'test1'})
+    
+    spectrum2 = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
+                        intensities=np.array([10, 10, 500], dtype="float"),
+                        metadata={"test_field": 'test2'})
+    # Write to test file
+    save_as_mgf([spectrum, spectrum], 'test.mgf')
+    assert os.path.isfile('test.mgf')
+
+    # Test if content of mgf file is correct
+    with open('test.mgf', 'r') as f:
+        mgf_content = f.readlines()
+    assert mgf_content[6] ==  mgf_content[12] == 'END IONS\n'
+    assert mgf_content[1].split("=")[1] == 'test1\n'
+    assert mgf_content[8].split("=")[1] == 'test2\n'
+    # Remove testfile again
+    os.remove('test.mgf')
+
+
+if __name__ == "__main__":
+    test_save_as_mgf_single_spectrum()
+    test_save_as_mgf_spectrum_list()

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -12,45 +12,47 @@ def test_save_as_mgf_single_spectrum():
                         metadata={"charge": -1,
                                   "inchi": '"InChI=1S/C6H12"',
                                   "pepmass": (100, 10.0),
-                                  "test_field": 'test'})
+                                  "test_field": "test"})
     # Write to test file
-    with tempfile.NamedTemporaryFile() as fp:
-        save_as_mgf(spectrum, fp.name)
+    with tempfile.TemporaryDirectory() as d:
+        f = os.path.join(d, "test.mgf")
+        save_as_mgf(spectrum, f)
 
         # test if file exists
-        assert os.path.isfile(fp.name)
+        assert os.path.isfile(f)
 
         # Test if content of mgf file is correct
-        with open(fp.name, 'r') as f:
+        with open(f, "r") as f:
             mgf_content = f.readlines()
-        assert mgf_content[0] == 'BEGIN IONS\n'
-        assert mgf_content[2] == 'CHARGE=1-\n'
-        assert mgf_content[4] == 'TEST_FIELD=test\n'
-        assert mgf_content[7].split(" ")[0] == '300.0'
+        assert mgf_content[0] == "BEGIN IONS\n"
+        assert mgf_content[2] == "CHARGE=1-\n"
+        assert mgf_content[4] == "TEST_FIELD=test\n"
+        assert mgf_content[7].split(" ")[0] == "300.0"
 
 
 def test_save_as_mgf_spectrum_list():
     """Test saving spectrum list to .mgf file"""
     spectrum1 = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
                          intensities=np.array([10, 10, 500], dtype="float"),
-                         metadata={"test_field": 'test1'})
+                         metadata={"test_field": "test1"})
 
     spectrum2 = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
                          intensities=np.array([10, 10, 500], dtype="float"),
-                         metadata={"test_field": 'test2'})
+                         metadata={"test_field": "test2"})
     # Write to test file
-    with tempfile.NamedTemporaryFile() as fp:
-        save_as_mgf([spectrum1, spectrum2], fp.name)
+    with tempfile.TemporaryDirectory() as d:
+        f = os.path.join(d, "test.mgf")
+        save_as_mgf([spectrum1, spectrum2], f)
 
         # test if file exists
-        assert os.path.isfile(fp.name)
+        assert os.path.isfile(f)
 
         # Test if content of mgf file is correct
-        with open(fp.name, 'r') as f:
+        with open(f, "r") as f:
             mgf_content = f.readlines()
-        assert mgf_content[5] == mgf_content[12] == 'END IONS\n'
-        assert mgf_content[1].split("=")[1] == 'test1\n'
-        assert mgf_content[8].split("=")[1] == 'test2\n'
+        assert mgf_content[5] == mgf_content[12] == "END IONS\n"
+        assert mgf_content[1].split("=")[1] == "test1\n"
+        assert mgf_content[8].split("=")[1] == "test2\n"
 
 
 if __name__ == "__main__":

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -2,9 +2,10 @@ import os
 import numpy as np
 from matchms import Spectrum
 from matchms.exporting import save_as_mgf
+import tempfile
 
 
-def test_save_as_mgf_single_spectrum(tmp_path):
+def test_save_as_mgf_single_spectrum():
     """Test saving spectrum to .mgf file"""
     spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
                         intensities=np.array([10, 10, 500], dtype="float"),
@@ -13,17 +14,19 @@ def test_save_as_mgf_single_spectrum(tmp_path):
                                   "pepmass": (100, 10.0),
                                   "test_field": 'test'})
     # Write to test file
-    file = tmp_path.join('test.mgf')
-    save_as_mgf(spectrum, file)
-    assert os.path.isfile(file)
+    with tempfile.NamedTemporaryFile() as fp:
+        save_as_mgf(spectrum, fp.name)
 
-    # Test if content of mgf file is correct
-    with open(file, 'r') as f:
-        mgf_content = f.readlines()
-    assert mgf_content[0] == 'BEGIN IONS\n'
-    assert mgf_content[2] == 'CHARGE=1-\n'
-    assert mgf_content[4] == 'TEST_FIELD=test\n'
-    assert mgf_content[7].split(" ")[0] == '300.0'
+        # test if file exists
+        assert os.path.isfile(fp.name)
+
+        # Test if content of mgf file is correct
+        with open(fp.name, 'r') as f:
+            mgf_content = f.readlines()
+        assert mgf_content[0] == 'BEGIN IONS\n'
+        assert mgf_content[2] == 'CHARGE=1-\n'
+        assert mgf_content[4] == 'TEST_FIELD=test\n'
+        assert mgf_content[7].split(" ")[0] == '300.0'
 
 
 def test_save_as_mgf_spectrum_list():
@@ -36,17 +39,18 @@ def test_save_as_mgf_spectrum_list():
                          intensities=np.array([10, 10, 500], dtype="float"),
                          metadata={"test_field": 'test2'})
     # Write to test file
-    save_as_mgf([spectrum1, spectrum2], 'test.mgf')
-    assert os.path.isfile('test.mgf')
+    with tempfile.NamedTemporaryFile() as fp:
+        save_as_mgf([spectrum1, spectrum2], fp.name)
 
-    # Test if content of mgf file is correct
-    with open('test.mgf', 'r') as f:
-        mgf_content = f.readlines()
-    assert mgf_content[5] == mgf_content[12] == 'END IONS\n'
-    assert mgf_content[1].split("=")[1] == 'test1\n'
-    assert mgf_content[8].split("=")[1] == 'test2\n'
-    # Remove testfile again
-    os.remove('test.mgf')
+        # test if file exists
+        assert os.path.isfile(fp.name)
+
+        # Test if content of mgf file is correct
+        with open(fp.name, 'r') as f:
+            mgf_content = f.readlines()
+        assert mgf_content[5] == mgf_content[12] == 'END IONS\n'
+        assert mgf_content[1].split("=")[1] == 'test1\n'
+        assert mgf_content[8].split("=")[1] == 'test2\n'
 
 
 if __name__ == "__main__":

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -30,20 +30,20 @@ def test_save_as_mgf_single_spectrum():
 def test_save_as_mgf_spectrum_list():
     """Test saving spectrum list to .mgf file"""
     spectrum1 = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
-                        intensities=np.array([10, 10, 500], dtype="float"),
-                        metadata={"test_field": 'test1'})
-    
+                         intensities=np.array([10, 10, 500], dtype="float"),
+                         metadata={"test_field": 'test1'})
+
     spectrum2 = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
-                        intensities=np.array([10, 10, 500], dtype="float"),
-                        metadata={"test_field": 'test2'})
+                         intensities=np.array([10, 10, 500], dtype="float"),
+                         metadata={"test_field": 'test2'})
     # Write to test file
-    save_as_mgf([spectrum, spectrum], 'test.mgf')
+    save_as_mgf([spectrum1, spectrum2], 'test.mgf')
     assert os.path.isfile('test.mgf')
 
     # Test if content of mgf file is correct
     with open('test.mgf', 'r') as f:
         mgf_content = f.readlines()
-    assert mgf_content[6] ==  mgf_content[12] == 'END IONS\n'
+    assert mgf_content[6] == mgf_content[12] == 'END IONS\n'
     assert mgf_content[1].split("=")[1] == 'test1\n'
     assert mgf_content[8].split("=")[1] == 'test2\n'
     # Remove testfile again

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -15,14 +15,14 @@ def test_save_as_mgf_single_spectrum():
                                   "test_field": "test"})
     # Write to test file
     with tempfile.TemporaryDirectory() as d:
-        f = os.path.join(d, "test.mgf")
-        save_as_mgf(spectrum, f)
+        filename = os.path.join(d, "test.mgf")
+        save_as_mgf(spectrum, filename)
 
         # test if file exists
-        assert os.path.isfile(f)
+        assert os.path.isfile(filename)
 
         # Test if content of mgf file is correct
-        with open(f, "r") as f:
+        with open(filename, "r") as f:
             mgf_content = f.readlines()
         assert mgf_content[0] == "BEGIN IONS\n"
         assert mgf_content[2] == "CHARGE=1-\n"
@@ -41,14 +41,14 @@ def test_save_as_mgf_spectrum_list():
                          metadata={"test_field": "test2"})
     # Write to test file
     with tempfile.TemporaryDirectory() as d:
-        f = os.path.join(d, "test.mgf")
-        save_as_mgf([spectrum1, spectrum2], f)
+        filename = os.path.join(d, "test.mgf")
+        save_as_mgf([spectrum1, spectrum2], filename)
 
         # test if file exists
-        assert os.path.isfile(f)
+        assert os.path.isfile(filename)
 
         # Test if content of mgf file is correct
-        with open(f, "r") as f:
+        with open(filename, "r") as f:
             mgf_content = f.readlines()
         assert mgf_content[5] == mgf_content[12] == "END IONS\n"
         assert mgf_content[1].split("=")[1] == "test1\n"

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -4,7 +4,7 @@ from matchms import Spectrum
 from matchms.exporting import save_as_mgf
 
 
-def test_save_as_mgf_single_spectrum(tmpdir):
+def test_save_as_mgf_single_spectrum(tmp_path):
     """Test saving spectrum to .mgf file"""
     spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
                         intensities=np.array([10, 10, 500], dtype="float"),
@@ -13,7 +13,7 @@ def test_save_as_mgf_single_spectrum(tmpdir):
                                   "pepmass": (100, 10.0),
                                   "test_field": 'test'})
     # Write to test file
-    file = tmpdir.join('test.mgf')
+    file = tmp_path.join('test.mgf')
     save_as_mgf(spectrum, file)
     assert os.path.isfile(file)
 
@@ -24,8 +24,6 @@ def test_save_as_mgf_single_spectrum(tmpdir):
     assert mgf_content[2] == 'CHARGE=1-\n'
     assert mgf_content[4] == 'TEST_FIELD=test\n'
     assert mgf_content[7].split(" ")[0] == '300.0'
-    # Remove testfile again
-    os.remove('test.mgf')
 
 
 def test_save_as_mgf_spectrum_list():
@@ -52,5 +50,5 @@ def test_save_as_mgf_spectrum_list():
 
 
 if __name__ == "__main__":
-    test_save_as_mgf_single_spectrum(tmpdir)
+    test_save_as_mgf_single_spectrum()
     test_save_as_mgf_spectrum_list()

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -43,7 +43,7 @@ def test_save_as_mgf_spectrum_list():
     # Test if content of mgf file is correct
     with open('test.mgf', 'r') as f:
         mgf_content = f.readlines()
-    assert mgf_content[6] == mgf_content[12] == 'END IONS\n'
+    assert mgf_content[5] == mgf_content[12] == 'END IONS\n'
     assert mgf_content[1].split("=")[1] == 'test1\n'
     assert mgf_content[8].split("=")[1] == 'test2\n'
     # Remove testfile again


### PR DESCRIPTION
- Added ``save_to_mgf`` function to save Spectrum (or list of Spectrum objects) to a single .mfg file.
- Added ``test_save_to_mgf`` unit test.
- Added save_to_mgf to init.
- Removed former dummy save.py.