### PR TITLE
require peaks

### DIFF
--- a/matchms/filtering/__init__.py
+++ b/matchms/filtering/__init__.py
@@ -8,7 +8,7 @@ from .make_charge_scalar import make_charge_scalar
 from .make_ionmode_lowercase import make_ionmode_lowercase
 from .set_ionmode_na_when_missing import set_ionmode_na_when_missing
 from .normalize_intensities import normalize_intensities
-from.require_minimum_number_of_peaks import require_minimum_number_of_peaks
+from .require_minimum_number_of_peaks import require_minimum_number_of_peaks
 from .select_by_intensity import select_by_intensity
 from .select_by_mz import select_by_mz
 from .select_by_relative_intensity import select_by_relative_intensity

--- a/matchms/filtering/__init__.py
+++ b/matchms/filtering/__init__.py
@@ -8,6 +8,7 @@ from .make_charge_scalar import make_charge_scalar
 from .make_ionmode_lowercase import make_ionmode_lowercase
 from .set_ionmode_na_when_missing import set_ionmode_na_when_missing
 from .normalize_intensities import normalize_intensities
+from.require_minimum_number_of_peaks import require_minimum_number_of_peaks
 from .select_by_intensity import select_by_intensity
 from .select_by_mz import select_by_mz
 from .select_by_relative_intensity import select_by_relative_intensity
@@ -23,6 +24,7 @@ __all__ = [
     "make_charge_scalar",
     "make_ionmode_lowercase",
     "normalize_intensities",
+    "require_minimum_number_of_peaks",
     "select_by_intensity",
     "select_by_mz",
     "select_by_relative_intensity",

--- a/matchms/filtering/correct_charge.py
+++ b/matchms/filtering/correct_charge.py
@@ -3,6 +3,9 @@ import numpy
 
 def correct_charge(spectrum_in):
 
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     ionmode = spectrum.get("ionmode", None)

--- a/matchms/filtering/derive_ionmode.py
+++ b/matchms/filtering/derive_ionmode.py
@@ -14,6 +14,9 @@ def derive_ionmode(spectrum_in):
         Input spectrum.
     """
 
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     # Load lists of known adducts

--- a/matchms/filtering/make_charge_scalar.py
+++ b/matchms/filtering/make_charge_scalar.py
@@ -1,4 +1,8 @@
 def make_charge_scalar(spectrum_in):
+
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     # Avoid pyteomics ChargeList

--- a/matchms/filtering/make_ionmode_lowercase.py
+++ b/matchms/filtering/make_ionmode_lowercase.py
@@ -1,5 +1,8 @@
 def make_ionmode_lowercase(spectrum_in):
 
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     # if the ionmode key exists in the metadata, lowercase its value

--- a/matchms/filtering/normalize_intensities.py
+++ b/matchms/filtering/normalize_intensities.py
@@ -3,6 +3,10 @@ import numpy
 
 def normalize_intensities(spectrum_in):
     """Normalize intensities to unit height."""
+
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     scale_factor = numpy.max(spectrum.intensities)

--- a/matchms/filtering/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/require_minimum_number_of_peaks.py
@@ -1,7 +1,7 @@
 from math import ceil
 
 
-def require_minimum_number_of_peaks(spectrum_in, n_required=10, required_peaks_ratio=None):
+def require_minimum_number_of_peaks(spectrum_in, n_required=10, ratio_required=None):
 
     if spectrum_in is None:
         return None
@@ -10,7 +10,7 @@ def require_minimum_number_of_peaks(spectrum_in, n_required=10, required_peaks_r
 
     parent_mass = spectrum.get("parent_mass", None)
     if parent_mass:
-        n_required_by_mass = int(ceil(required_peaks_ratio * parent_mass))
+        n_required_by_mass = int(ceil(ratio_required * parent_mass))
         threshold = max(n_required, n_required_by_mass)
     else:
         threshold = n_required

--- a/matchms/filtering/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/require_minimum_number_of_peaks.py
@@ -1,0 +1,21 @@
+from math import ceil
+
+
+def require_minimum_number_of_peaks(spectrum_in, n_required=10, required_peaks_ratio=None):
+
+    if spectrum_in is None:
+        return None
+
+    spectrum = spectrum_in.clone()
+
+    parent_mass = spectrum.get("parent_mass", None)
+    if parent_mass:
+        n_required_by_mass = int(ceil(required_peaks_ratio * parent_mass))
+        threshold = max(n_required, n_required_by_mass)
+    else:
+        threshold = n_required
+
+    if spectrum.intensities.size < threshold:
+        return None
+
+    return spectrum

--- a/matchms/filtering/select_by_intensity.py
+++ b/matchms/filtering/select_by_intensity.py
@@ -3,6 +3,9 @@ import numpy
 
 def select_by_intensity(spectrum_in, intensity_from=10.0, intensity_to=200.0):
 
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."

--- a/matchms/filtering/select_by_mz.py
+++ b/matchms/filtering/select_by_mz.py
@@ -3,6 +3,9 @@ import numpy
 
 def select_by_mz(spectrum_in, mz_from=0.0, mz_to=1000.0):
 
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     assert mz_from <= mz_to, "'mz_from' should be smaller than or equal to 'mz_to'."

--- a/matchms/filtering/select_by_relative_intensity.py
+++ b/matchms/filtering/select_by_relative_intensity.py
@@ -3,6 +3,9 @@ import numpy
 
 def select_by_relative_intensity(spectrum_in, intensity_from=0.0, intensity_to=1.0):
 
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     assert intensity_from >= 0.0, "'intensity_from' should be larger than or equal to 0."

--- a/matchms/filtering/set_ionmode_na_when_missing.py
+++ b/matchms/filtering/set_ionmode_na_when_missing.py
@@ -1,5 +1,8 @@
 def set_ionmode_na_when_missing(spectrum_in):
 
+    if spectrum_in is None:
+        return None
+
     spectrum = spectrum_in.clone()
 
     # Set ionmode to "n/a" when ionmode is missing from the metadata

--- a/tests/test_require_minimum_number_of_peaks.py
+++ b/tests/test_require_minimum_number_of_peaks.py
@@ -60,8 +60,8 @@ def test_require_minimum_number_of_peaks_required_4_or_10():
 
     spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, required_peaks_ratio=0.1)
 
-    assert spectrum is None , "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
-                              "than the required number (10)."
+    assert spectrum is None, "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
+                             "than the required number (10)."
 
 
 def test_require_minimum_number_of_peaks_required_5_or_1():

--- a/tests/test_require_minimum_number_of_peaks.py
+++ b/tests/test_require_minimum_number_of_peaks.py
@@ -26,6 +26,18 @@ def test_require_minimum_number_of_peaks_required_4():
                                     "required number (4)."
 
 
+def test_require_minimum_number_of_peaks_required_4_or_1_no_parent_mass():
+
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    spectrum_in = Spectrum(mz=mz, intensities=intensities)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, required_peaks_ratio=0.1)
+
+    assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
+                                    "required number (4)."
+
+
 def test_require_minimum_number_of_peaks_required_4_or_1():
 
     mz = numpy.array([10, 20, 30, 40], dtype='float')
@@ -81,6 +93,7 @@ def test_require_minimum_number_of_peaks_required_5_or_10():
 if __name__ == '__main__':
     test_require_minimum_number_of_peaks_no_params()
     test_require_minimum_number_of_peaks_required_4()
+    test_require_minimum_number_of_peaks_required_4_or_1_no_parent_mass()
     test_require_minimum_number_of_peaks_required_4_or_1()
     test_require_minimum_number_of_peaks_required_4_or_10()
     test_require_minimum_number_of_peaks_required_5_or_1()

--- a/tests/test_require_minimum_number_of_peaks.py
+++ b/tests/test_require_minimum_number_of_peaks.py
@@ -32,7 +32,7 @@ def test_require_minimum_number_of_peaks_required_4_or_1_no_parent_mass():
     intensities = numpy.array([0, 1, 10, 100], dtype='float')
     spectrum_in = Spectrum(mz=mz, intensities=intensities)
 
-    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, required_peaks_ratio=0.1)
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, ratio_required=0.1)
 
     assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
                                     "required number (4)."
@@ -45,7 +45,7 @@ def test_require_minimum_number_of_peaks_required_4_or_1():
     metadata = dict(parent_mass=10)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
-    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, required_peaks_ratio=0.1)
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, ratio_required=0.1)
 
     assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
                                     "required number (4)."
@@ -58,7 +58,7 @@ def test_require_minimum_number_of_peaks_required_4_or_10():
     metadata = dict(parent_mass=100)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
-    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, required_peaks_ratio=0.1)
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, ratio_required=0.1)
 
     assert spectrum is None, "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
                              "than the required number (10)."
@@ -71,7 +71,7 @@ def test_require_minimum_number_of_peaks_required_5_or_1():
     metadata = dict(parent_mass=10)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
-    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=5, required_peaks_ratio=0.1)
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=5, ratio_required=0.1)
 
     assert spectrum is None, "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
                              "than the required number (5)."
@@ -84,7 +84,7 @@ def test_require_minimum_number_of_peaks_required_5_or_10():
     metadata = dict(parent_mass=100)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
-    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=5, required_peaks_ratio=0.1)
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=5, ratio_required=0.1)
 
     assert spectrum is None, "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
                              "than the required number (10)."

--- a/tests/test_require_minimum_number_of_peaks.py
+++ b/tests/test_require_minimum_number_of_peaks.py
@@ -1,0 +1,87 @@
+from matchms import Spectrum
+from matchms.filtering import require_minimum_number_of_peaks
+import numpy
+
+
+def test_require_minimum_number_of_peaks_no_params():
+
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    spectrum_in = Spectrum(mz=mz, intensities=intensities)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in)
+
+    assert spectrum is None, "Expected None because the number of peaks (4) is less than the default threshold (10)."
+
+
+def test_require_minimum_number_of_peaks_required_4():
+
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    spectrum_in = Spectrum(mz=mz, intensities=intensities)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4)
+
+    assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
+                                    "required number (4)."
+
+
+def test_require_minimum_number_of_peaks_required_4_or_1():
+
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    metadata = dict(parent_mass=10)
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, required_peaks_ratio=0.1)
+
+    assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
+                                    "required number (4)."
+
+
+def test_require_minimum_number_of_peaks_required_4_or_10():
+
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    metadata = dict(parent_mass=100)
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, required_peaks_ratio=0.1)
+
+    assert spectrum is None , "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
+                              "than the required number (10)."
+
+
+def test_require_minimum_number_of_peaks_required_5_or_1():
+
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    metadata = dict(parent_mass=10)
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=5, required_peaks_ratio=0.1)
+
+    assert spectrum is None, "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
+                             "than the required number (5)."
+
+
+def test_require_minimum_number_of_peaks_required_5_or_10():
+
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    metadata = dict(parent_mass=100)
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=5, required_peaks_ratio=0.1)
+
+    assert spectrum is None, "Did not expect the spectrum to qualify because the number of peaks (4) is less " \
+                             "than the required number (10)."
+
+
+if __name__ == '__main__':
+    test_require_minimum_number_of_peaks_no_params()
+    test_require_minimum_number_of_peaks_required_4()
+    test_require_minimum_number_of_peaks_required_4_or_1()
+    test_require_minimum_number_of_peaks_required_4_or_10()
+    test_require_minimum_number_of_peaks_required_5_or_1()
+    test_require_minimum_number_of_peaks_required_5_or_10()


### PR DESCRIPTION
refs #90 

This issue adds a new filter, ``require_minimum_number_of_peaks``. It is similar but not equal to https://github.com/matchms/old-iomega-spec2vec/blob/216b8f8b5e4ffd320b4575326a05fb6c7cd28223/matchms/old/ms_functions.py#L591-L593

Here are some features of this implementation:
1. The absolute minimum required peaks can be set by a user via the ``n_required=10`` parameter; this condition needs to met at all times.
1. The minimum required peaks as related to mz of parent can be set separately via the ``ratio_required`` parameter (in the old implementation it was related to the absolute threshold). If set, the condition needs to be met at all times
1. The filter returns ``None`` for non-qualifying spectrums 

The implication of this last item is that I adapted all filters to be able to deal with input spectrums being None, and that the user code should include a list comprehension along the lines of 

```python
spectrums = [s for s in spectrums if s is not None]
```
