### PR TITLE
Add new test case and fix to require_minimum_number_of_peaks filter

### DIFF
--- a/matchms/filtering/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/require_minimum_number_of_peaks.py
@@ -2,14 +2,26 @@ from math import ceil
 
 
 def require_minimum_number_of_peaks(spectrum_in, n_required=10, ratio_required=None):
-
+    """Spectrum will be set to None when it has fewer peaks than required.
+    
+    Args:
+    ----
+    spectrum_in: matchms.Spectrum()
+        Input spectrum.
+    n_required: int
+        Number of minimum required peaks. Spectra with fewer peaks will be set 
+        to 'None'.
+    ratio_required: float, optional
+        Set desired ratio between minimum number of peaks and parent mass.
+        Default is None.
+    """
     if spectrum_in is None:
         return None
 
     spectrum = spectrum_in.clone()
 
     parent_mass = spectrum.get("parent_mass", None)
-    if parent_mass:
+    if parent_mass and ratio_required:
         n_required_by_mass = int(ceil(ratio_required * parent_mass))
         threshold = max(n_required, n_required_by_mass)
     else:

--- a/matchms/filtering/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/require_minimum_number_of_peaks.py
@@ -3,13 +3,13 @@ from math import ceil
 
 def require_minimum_number_of_peaks(spectrum_in, n_required=10, ratio_required=None):
     """Spectrum will be set to None when it has fewer peaks than required.
-    
+
     Args:
     ----
     spectrum_in: matchms.Spectrum()
         Input spectrum.
     n_required: int
-        Number of minimum required peaks. Spectra with fewer peaks will be set 
+        Number of minimum required peaks. Spectra with fewer peaks will be set
         to 'None'.
     ratio_required: float, optional
         Set desired ratio between minimum number of peaks and parent mass.

--- a/tests/test_require_minimum_number_of_peaks.py
+++ b/tests/test_require_minimum_number_of_peaks.py
@@ -51,6 +51,19 @@ def test_require_minimum_number_of_peaks_required_4_or_1():
                                     "required number (4)."
 
 
+def test_require_minimum_number_of_peaks_required_4_ratio_none():
+    """Test if parent_mass scaling is properly ignored when not passing ratio_required."""
+    mz = numpy.array([10, 20, 30, 40], dtype='float')
+    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    metadata = dict(parent_mass=100)
+    spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
+
+    spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4)
+
+    assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
+                                    "required number (4)."
+
+
 def test_require_minimum_number_of_peaks_required_4_or_10():
 
     mz = numpy.array([10, 20, 30, 40], dtype='float')

--- a/tests/test_require_minimum_number_of_peaks.py
+++ b/tests/test_require_minimum_number_of_peaks.py
@@ -5,8 +5,8 @@ import numpy
 
 def test_require_minimum_number_of_peaks_no_params():
 
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     spectrum_in = Spectrum(mz=mz, intensities=intensities)
 
     spectrum = require_minimum_number_of_peaks(spectrum_in)
@@ -16,8 +16,8 @@ def test_require_minimum_number_of_peaks_no_params():
 
 def test_require_minimum_number_of_peaks_required_4():
 
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     spectrum_in = Spectrum(mz=mz, intensities=intensities)
 
     spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4)
@@ -28,8 +28,8 @@ def test_require_minimum_number_of_peaks_required_4():
 
 def test_require_minimum_number_of_peaks_required_4_or_1_no_parent_mass():
 
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     spectrum_in = Spectrum(mz=mz, intensities=intensities)
 
     spectrum = require_minimum_number_of_peaks(spectrum_in, n_required=4, ratio_required=0.1)
@@ -40,8 +40,8 @@ def test_require_minimum_number_of_peaks_required_4_or_1_no_parent_mass():
 
 def test_require_minimum_number_of_peaks_required_4_or_1():
 
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     metadata = dict(parent_mass=10)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
@@ -53,8 +53,8 @@ def test_require_minimum_number_of_peaks_required_4_or_1():
 
 def test_require_minimum_number_of_peaks_required_4_ratio_none():
     """Test if parent_mass scaling is properly ignored when not passing ratio_required."""
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     metadata = dict(parent_mass=100)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
@@ -66,8 +66,8 @@ def test_require_minimum_number_of_peaks_required_4_ratio_none():
 
 def test_require_minimum_number_of_peaks_required_4_or_10():
 
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     metadata = dict(parent_mass=100)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
@@ -79,8 +79,8 @@ def test_require_minimum_number_of_peaks_required_4_or_10():
 
 def test_require_minimum_number_of_peaks_required_5_or_1():
 
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     metadata = dict(parent_mass=10)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 
@@ -92,8 +92,8 @@ def test_require_minimum_number_of_peaks_required_5_or_1():
 
 def test_require_minimum_number_of_peaks_required_5_or_10():
 
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
+    mz = numpy.array([10, 20, 30, 40], dtype="float")
+    intensities = numpy.array([0, 1, 10, 100], dtype="float")
     metadata = dict(parent_mass=100)
     spectrum_in = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
 


### PR DESCRIPTION
When working on the actual data ``require_minimum_number_of_peaks`` failed because of ``TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'`` (which happens when ratio_required is None and a parent_mass is present). 

- I added the respective  scenario to the tests.
- The filter function was fixed (and a docstring added).