### PR TITLE
Added weighing words by intensity

### DIFF
--- a/matchms/similarity/spec2vec/Spec2Vec.py
+++ b/matchms/similarity/spec2vec/Spec2Vec.py
@@ -22,7 +22,6 @@ class Spec2Vec:
         if intensity_weighting_power:
             vector_size = self.model.wv.vector_size
             word_weights = numpy.power(document.weights, intensity_weighting_power)
-            # word_weights = word_weights/numpy.sum(word_weights)  # normalize weights? better not
-            return numpy.mean(word_vectors * numpy.tile(word_weights, (vector_size, 1)).T, 0)
+            return numpy.sum(word_vectors * numpy.tile(word_weights, (vector_size, 1)).T, 0)
 
-        return numpy.mean(word_vectors, 0)
+        return numpy.sum(word_vectors, 0)

--- a/matchms/similarity/spec2vec/SpectrumDocument.py
+++ b/matchms/similarity/spec2vec/SpectrumDocument.py
@@ -5,8 +5,10 @@ class SpectrumDocument(Document):
     def __init__(self, spectrum, n_decimals=1):
         self.n_decimals = n_decimals
         super().__init__(obj=spectrum)
+        self._add_weights()
 
     def _make_words(self):
+        """Create word from peaks (and losses)."""
         format_string = "{}@{:." + "{}".format(self.n_decimals) + "f}"
         peak_words = [format_string.format("peak", mz) for mz in self._obj.peaks.mz]
         if self._obj.losses is not None:
@@ -14,4 +16,16 @@ class SpectrumDocument(Document):
         else:
             loss_words = []
         self.words = peak_words + loss_words
+        return self
+
+    def _add_weights(self):
+        """Add peaks (and loss) intensities as weights."""
+        assert self._obj.peaks.intensities.max() <= 1, "peak intensities not normalized"
+
+        peak_intensities = self._obj.peaks.intensities.tolist()
+        if self._obj.losses is not None:
+            loss_intensities = self._obj.losses.intensities.tolist()
+        else:
+            loss_intensities = []
+        self.weights = peak_intensities + loss_intensities
         return self


### PR DESCRIPTION
- Added ``.weights`` to SpectrumDocument.
- Added weighing words by intensity to ``Spec2Vec`` class.
For this I had to change the calc_vector function. The former transformation to bag_of_word and  messing up the peak order.
- I made ``calc_vector`` callable separately, so that it is possible get the word vectors when needed.
- I changed the spectrum vector calculation from ``mean()`` of all (weighted) word vectors to the ``sum()`` to stick to the original NLP implementation (see https://github.com/matchms/matchms/issues/142#issuecomment-621790462)

This PR will close #142.