### PR TITLE
Fix to sorting issues with Spikes

### DIFF
--- a/matchms/Spikes.py
+++ b/matchms/Spikes.py
@@ -28,7 +28,7 @@ class Spikes:
         return [self.mz, self.intensities][item]
 
     def _is_sorted(self):
-        return numpy.all(self.mz[:-1] < self.mz[1:])
+        return numpy.all(self.mz[:-1] <= self.mz[1:])
 
     def clone(self):
         return Spikes(self.mz, self.intensities)

--- a/matchms/importing/load_from_mgf.py
+++ b/matchms/importing/load_from_mgf.py
@@ -1,10 +1,11 @@
+import numpy as np
 from typing import List
 from pyteomics.mgf import MGF
 from ..Spectrum import Spectrum
 
 
 def load_from_mgf(filename: str) -> List[Spectrum]:
-    """load from mgf file"""
+    """Load spectrum(s) from mgf file."""
 
     spectrums = list()
     for pyteomics_spectrum in MGF(filename, convert_arrays=1):
@@ -12,6 +13,12 @@ def load_from_mgf(filename: str) -> List[Spectrum]:
         metadata = pyteomics_spectrum.get("params", None)
         mz = pyteomics_spectrum["m/z array"]
         intensities = pyteomics_spectrum["intensity array"]
+
+        # Sort by mz (if not sorted already)
+        if not np.all(mz[:-1] < mz[1:]):
+            idx_sorted = np.argsort(mz)
+            mz = mz[idx_sorted]
+            intensities = intensities[idx_sorted]
 
         spectrum = Spectrum(mz=mz, intensities=intensities, metadata=metadata)
         spectrums.append(spectrum)

--- a/matchms/importing/load_from_mgf.py
+++ b/matchms/importing/load_from_mgf.py
@@ -15,7 +15,7 @@ def load_from_mgf(filename: str) -> List[Spectrum]:
         intensities = pyteomics_spectrum["intensity array"]
 
         # Sort by mz (if not sorted already)
-        if not np.all(mz[:-1] < mz[1:]):
+        if not np.all(mz[:-1] <= mz[1:]):
             idx_sorted = np.argsort(mz)
             mz = mz[idx_sorted]
             intensities = intensities[idx_sorted]


### PR DESCRIPTION
When running matchms with the actual data I got two issues:
- For some spectra in the mgf the peaks are not sorted by mz which is not what Spikes expects (I here added a mz sorting to the import function instead of a separate filter to be able to import the data).
- Some spectra have identical peaks which also causes Spikes to break (I changed the ``is_sorted`` to accept ``<=`` instead of only ``<``).