### PR TITLE
Switch from openbabel to rdkit

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - gensim==3.8.0
   - matplotlib==3.2.1
   - numpy==1.18.1
-  - openbabel==3.0.0
   - pip==20.0.2
   - pyteomics==4.2
   - python==3.7

--- a/matchms/filtering/derive_inchi_from_smiles.py
+++ b/matchms/filtering/derive_inchi_from_smiles.py
@@ -14,7 +14,7 @@ def derive_inchi_from_smiles(spectrum_in: SpectrumType) -> SpectrumType:
     if not is_valid_inchi(inchi) and is_valid_smiles(smiles):
         inchi = mol_converter(smiles, "smiles", "inchi")
         if inchi:
-            inchi = inchi.replace('\n', '').replace('\t', '').replace('\r', '')
+            inchi = inchi.rstrip()
             spectrum.set("inchi", inchi)
         else:
             print("Could not convert smiles", smiles, "to InChI.")

--- a/matchms/filtering/derive_inchi_from_smiles.py
+++ b/matchms/filtering/derive_inchi_from_smiles.py
@@ -12,7 +12,7 @@ def derive_inchi_from_smiles(spectrum_in: SpectrumType) -> SpectrumType:
     smiles = spectrum.get("smiles")
 
     if not is_valid_inchi(inchi) and is_valid_smiles(smiles):
-        inchi = mol_converter(smiles, "smi", "inchi")
+        inchi = mol_converter(smiles, "smiles", "inchi")
         if not inchi:
             # Second try: use smiley ("smy") parser
             inchi = mol_converter(smiles, "smy", "inchi")

--- a/matchms/filtering/derive_inchi_from_smiles.py
+++ b/matchms/filtering/derive_inchi_from_smiles.py
@@ -1,5 +1,5 @@
 from ..typing import SpectrumType
-from ..utils import mol_converter, is_valid_inchi, is_valid_smiles
+from ..utils import convert_smiles_to_inchi, is_valid_inchi, is_valid_smiles
 
 
 def derive_inchi_from_smiles(spectrum_in: SpectrumType) -> SpectrumType:
@@ -12,7 +12,7 @@ def derive_inchi_from_smiles(spectrum_in: SpectrumType) -> SpectrumType:
     smiles = spectrum.get("smiles")
 
     if not is_valid_inchi(inchi) and is_valid_smiles(smiles):
-        inchi = mol_converter(smiles, "smiles", "inchi")
+        inchi = convert_smiles_to_inchi(smiles)
         if inchi:
             inchi = inchi.rstrip()
             spectrum.set("inchi", inchi)

--- a/matchms/filtering/derive_inchi_from_smiles.py
+++ b/matchms/filtering/derive_inchi_from_smiles.py
@@ -13,9 +13,6 @@ def derive_inchi_from_smiles(spectrum_in: SpectrumType) -> SpectrumType:
 
     if not is_valid_inchi(inchi) and is_valid_smiles(smiles):
         inchi = mol_converter(smiles, "smiles", "inchi")
-        if not inchi:
-            # Second try: use smiley ("smy") parser
-            inchi = mol_converter(smiles, "smy", "inchi")
         if inchi:
             inchi = inchi.replace('\n', '').replace('\t', '').replace('\r', '')
             spectrum.set("inchi", inchi)

--- a/matchms/filtering/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/derive_inchikey_from_inchi.py
@@ -1,5 +1,5 @@
-from ..utils import mol_converter, is_valid_inchi, is_valid_inchikey
 from ..typing import SpectrumType
+from ..utils import convert_inchi_to_inchikey, is_valid_inchi, is_valid_inchikey
 
 
 def derive_inchikey_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
@@ -13,7 +13,7 @@ def derive_inchikey_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
     inchikey = spectrum.get("inchikey")
 
     if is_valid_inchi(inchi) and not is_valid_inchikey(inchikey):
-        inchikey = mol_converter(inchi, "inchi", "inchikey")
+        inchikey = convert_inchi_to_inchikey(inchi)
         if inchikey:
             spectrum.set("inchikey", inchikey)
         else:

--- a/matchms/filtering/derive_smiles_from_inchi.py
+++ b/matchms/filtering/derive_smiles_from_inchi.py
@@ -1,5 +1,5 @@
-from ..utils import mol_converter, is_valid_smiles, is_valid_inchi
 from ..typing import SpectrumType
+from ..utils import convert_inchi_to_smiles, is_valid_smiles, is_valid_inchi
 
 
 def derive_smiles_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
@@ -12,7 +12,7 @@ def derive_smiles_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
     smiles = spectrum.get("smiles")
 
     if not is_valid_smiles(smiles) and is_valid_inchi(inchi):
-        smiles = mol_converter(inchi, "inchi", "smiles")
+        smiles = convert_inchi_to_smiles(inchi)
         if smiles:
             smiles = smiles.rstrip()
             spectrum.set("smiles", smiles)

--- a/matchms/filtering/derive_smiles_from_inchi.py
+++ b/matchms/filtering/derive_smiles_from_inchi.py
@@ -14,7 +14,7 @@ def derive_smiles_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
     if not is_valid_smiles(smiles) and is_valid_inchi(inchi):
         smiles = mol_converter(inchi, "inchi", "smiles")
         if smiles:
-            smiles = smiles.replace('\n', '').replace('\t', '').replace('\r', '')
+            smiles = smiles.rstrip()
             spectrum.set("smiles", smiles)
         else:
             print("Could not convert InChI", inchi, "to smiles.")

--- a/matchms/filtering/derive_smiles_from_inchi.py
+++ b/matchms/filtering/derive_smiles_from_inchi.py
@@ -12,7 +12,7 @@ def derive_smiles_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
     smiles = spectrum.get("smiles")
 
     if not is_valid_smiles(smiles) and is_valid_inchi(inchi):
-        smiles = mol_converter(inchi, "inchi", "smi")
+        smiles = mol_converter(inchi, "inchi", "smiles")
         if smiles:
             smiles = smiles.replace('\n', '').replace('\t', '').replace('\r', '')
             spectrum.set("smiles", smiles)

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -1,32 +1,48 @@
 import re
-from openbabel import openbabel as ob
 from rdkit import Chem
 
 
 def mol_converter(mol_input, input_type, output_type):
-    """Convert molecular representations using openbabel.
+    """Convert molecular representations using rdkit.
 
-    Convert for instance from smiles to inchi or inchi to inchikey.
+    Convert for from smiles or inchi to inchi, smiles, or inchikey.
 
     Args:
     ----
     mol_input: str
-        Input data, e.g. inchi or smiles.
+        Input data, inchi or smiles.
     input_type: str
-        Define input type (as named in openbabel). E.g. "smi"for smiles and "inchi" for inchi.
+        Define input type: "smiles" for smiles and "inchi" for inchi.
     output_type: str
-        Define input type (as named in openbabel). E.g. "smi"for smiles and "inchi" for inchi.
+        Define output type: "smiles", "inchi", or "inchikey".
     """
-    conv = ob.OBConversion()
-    conv.SetInAndOutFormats(input_type, output_type)
-    mol = ob.OBMol()
-    if conv.ReadString(mol, mol_input):
-        mol_output = conv.WriteString(mol)
+    if input_type == "inchi":
+        mol = Chem.MolFromInchi(mol_input.replace('"', ""))  # rdkit can't handle '"'
+    elif input_type == "smiles":
+        mol = Chem.MolFromSmiles(mol_input)
     else:
-        print("Error when converting", mol_input)
-        mol_output = None
+        print("Unknown input type.")
+        return None
 
-    return mol_output
+    if mol is None:
+        return None
+
+    if output_type  == "smiles":
+        smiles = Chem.MolToSmiles(mol)
+        if smiles:
+            return smiles
+
+    if output_type == "inchi":
+        inchi = Chem.MolToInchi(mol)
+        if inchi:
+            return inchi
+
+    if output_type == "inchikey":
+        inchikey = Chem.MolToInchiKey(mol)
+        if inchikey:
+            return inchikey
+
+    return None
 
 
 def is_valid_inchi(inchi):

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -27,7 +27,7 @@ def mol_converter(mol_input, input_type, output_type):
     if mol is None:
         return None
 
-    if output_type  == "smiles":
+    if output_type == "smiles":
         smiles = Chem.MolToSmiles(mol)
         if smiles:
             return smiles

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -2,6 +2,18 @@ import re
 from rdkit import Chem
 
 
+def convert_smiles_to_inchi(smiles):
+    return mol_converter(smiles, "smiles", "inchi")
+
+
+def convert_inchi_to_smiles(inchi):
+    return mol_converter(inchi, "inchi", "smiles")
+
+
+def convert_inchi_to_inchikey(inchi):
+    return mol_converter(inchi, "inchi", "inchikey")
+
+
 def mol_converter(mol_input, input_type, output_type):
     """Convert molecular representations using rdkit.
 

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -1,5 +1,5 @@
 import re
-import rdkit
+from rdkit import Chem
 
 
 def mol_converter(mol_input, input_type, output_type):
@@ -16,11 +16,11 @@ def mol_converter(mol_input, input_type, output_type):
     output_type: str
         Define output type: "smiles", "inchi", or "inchikey".
     """
-    input_function = {"inchi": rdkit.Chem.MolFromInchi,
-                      "smiles": rdkit.Chem.MolFromSmiles}
-    output_function = {"inchi": rdkit.Chem.MolToInchi,
-                       "smiles": rdkit.Chem.MolToSmiles,
-                       "inchikey": rdkit.Chem.MolToInchiKey}
+    input_function = {"inchi": Chem.MolFromInchi,
+                      "smiles": Chem.MolFromSmiles}
+    output_function = {"inchi": Chem.MolToInchi,
+                       "smiles": Chem.MolToSmiles,
+                       "inchikey": Chem.MolToInchiKey}
 
     mol = input_function[input_type](mol_input)
     if mol is None:
@@ -50,7 +50,7 @@ def is_valid_inchi(inchi):
     if not re.search(regexp, inchi):
         return False
     # Proper chemical test
-    mol = rdkit.Chem.MolFromInchi(inchi)
+    mol = Chem.MolFromInchi(inchi)
     if mol:
         return True
     return False
@@ -73,7 +73,7 @@ def is_valid_smiles(smiles):
     if not re.match(regexp, smiles):
         return False
 
-    mol = rdkit.Chem.MolFromSmiles(smiles)
+    mol = Chem.MolFromSmiles(smiles)
     if mol:
         return True
     return False

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -1,5 +1,5 @@
 import re
-from rdkit import Chem
+import rdkit
 
 
 def mol_converter(mol_input, input_type, output_type):
@@ -17,9 +17,9 @@ def mol_converter(mol_input, input_type, output_type):
         Define output type: "smiles", "inchi", or "inchikey".
     """
     if input_type == "inchi":
-        mol = Chem.MolFromInchi(mol_input.replace('"', ""))  # rdkit can't handle '"'
+        mol = rdkit.Chem.MolFromInchi(mol_input.strip('"'))  # rdkit can't handle '"'
     elif input_type == "smiles":
-        mol = Chem.MolFromSmiles(mol_input)
+        mol = rdkit.Chem.MolFromSmiles(mol_input)
     else:
         print("Unknown input type.")
         return None
@@ -28,17 +28,17 @@ def mol_converter(mol_input, input_type, output_type):
         return None
 
     if output_type == "smiles":
-        smiles = Chem.MolToSmiles(mol)
+        smiles = rdkit.Chem.MolToSmiles(mol)
         if smiles:
             return smiles
 
     if output_type == "inchi":
-        inchi = Chem.MolToInchi(mol)
+        inchi = rdkit.Chem.MolToInchi(mol)
         if inchi:
             return inchi
 
     if output_type == "inchikey":
-        inchikey = Chem.MolToInchiKey(mol)
+        inchikey = rdkit.Chem.MolToInchiKey(mol)
         if inchikey:
             return inchikey
 
@@ -58,12 +58,12 @@ def is_valid_inchi(inchi):
     # First quick test to avoid excess in-depth testing
     if inchi is None:
         return False
-    inchi = inchi.replace('"', "")
+    inchi = inchi.strip('"')
     regexp = r"(InChI=1|1)(S\/|\/)[0-9, A-Z, a-z,\.]{2,}\/(c|h)[0-9]"
     if not re.search(regexp, inchi):
         return False
     # Proper chemical test
-    mol = Chem.MolFromInchi(inchi)
+    mol = rdkit.Chem.MolFromInchi(inchi)
     if mol:
         return True
     return False
@@ -86,7 +86,7 @@ def is_valid_smiles(smiles):
     if not re.match(regexp, smiles):
         return False
 
-    mol = Chem.MolFromSmiles(smiles)
+    mol = rdkit.Chem.MolFromSmiles(smiles)
     if mol:
         return True
     return False

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -22,7 +22,7 @@ def mol_converter(mol_input, input_type, output_type):
                        "smiles": Chem.MolToSmiles,
                        "inchikey": Chem.MolToInchiKey}
 
-    mol = input_function[input_type](mol_input)
+    mol = input_function[input_type](mol_input.strip('"'))
     if mol is None:
         return None
 

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -16,32 +16,19 @@ def mol_converter(mol_input, input_type, output_type):
     output_type: str
         Define output type: "smiles", "inchi", or "inchikey".
     """
-    if input_type == "inchi":
-        mol = rdkit.Chem.MolFromInchi(mol_input.strip('"'))  # rdkit can't handle '"'
-    elif input_type == "smiles":
-        mol = rdkit.Chem.MolFromSmiles(mol_input)
-    else:
-        print("Unknown input type.")
-        return None
+    input_function = {"inchi": rdkit.Chem.MolFromInchi,
+                      "smiles": rdkit.Chem.MolFromSmiles}
+    output_function = {"inchi": rdkit.Chem.MolToInchi,
+                       "smiles": rdkit.Chem.MolToSmiles,
+                       "inchikey": rdkit.Chem.MolToInchiKey}
 
+    mol = input_function[input_type](mol_input)
     if mol is None:
         return None
 
-    if output_type == "smiles":
-        smiles = rdkit.Chem.MolToSmiles(mol)
-        if smiles:
-            return smiles
-
-    if output_type == "inchi":
-        inchi = rdkit.Chem.MolToInchi(mol)
-        if inchi:
-            return inchi
-
-    if output_type == "inchikey":
-        inchikey = rdkit.Chem.MolToInchiKey(mol)
-        if inchikey:
-            return inchikey
-
+    output = output_function[output_type](mol)
+    if output:
+        return output
     return None
 
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - python==3.7
     - matplotlib==3.2.1
     - numpy==1.18.1
-    - openbabel==3.0.0
     - pyyaml==5.3.1
     - pycodestyle==2.5.0
     - pytest==5.4.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,8 +33,7 @@ def test_is_valid_inchikey():
         "XYLJNLCSTIOKRM-UHFFFAOYSA-NN",
         "Brcc(NC2=NCN2)-ccc3nccnc1-3",
         "2YLJNLCSTIOKRM-UHFFFAOYSA-N",
-        "XYLJNLCSTIOKRM-aaaaaaaaaa-a"
-        ]
+        "XYLJNLCSTIOKRM-aaaaaaaaaa-a"]
 
     for inchikey in inchikeys_true:
         assert is_valid_inchikey(inchikey), "Expected inchikey is True."
@@ -46,14 +45,12 @@ def test_is_valid_inchi():
     """Test if strings are correctly classified."""
     inchi_true = [
         "InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-        '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"'
-        ]
+        '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"']
     inchi_false = [
         "1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
         "InChI=1S/C2H7N3/c152(3)4/h1H3,(H4,3,4,5)",
         "InChI=C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-        "InChI=1S/C2H7N3/c1-5-2(3)"
-        ]
+        "InChI=1S/C2H7N3/c1-5-2(3)"]
 
     for inchi in inchi_true:
         assert is_valid_inchi(inchi), "Expected inchi is True."
@@ -66,14 +63,12 @@ def test_is_valid_smiles():
     smiles_true = [
         r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
         r"CN1N(C(=O)C=C1C)c1ccccc1",
-        r"COC(=O)C1=CN=CC=N1"
-        ]
+        r"COC(=O)C1=CN=CC=N1"]
     smiles_false = [
         r"CN1N(C(=O)C=C1C)c1cccccx1",
         r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
         r"COC(=O[)]C1=CN=CC=N1",
-        r"1S/C2H7N3/c1-5-2(3)4"
-        ]
+        r"1S/C2H7N3/c1-5-2(3)4"]
 
     for smiles in smiles_true:
         assert is_valid_smiles(smiles), "Expected smiles is True."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,14 +60,14 @@ def test_is_valid_inchi():
 def test_is_valid_smiles():
     """Test if strings are correctly classified."""
     smiles_true = ["CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
-                  "CN1N(C(=O)C=C1C)c1ccccc1",
-                  "COC(=O)C1=CN=CC=N1"
-                  ]
-    smiles_false = ["CN1N(C(=O)C=C1C)c1cccccx1",
-                   "CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
-                   "COC(=O[)]C1=CN=CC=N1",
-                   "1S/C2H7N3/c1-5-2(3)4"
+                   "CN1N(C(=O)C=C1C)c1ccccc1",
+                   "COC(=O)C1=CN=CC=N1"
                    ]
+    smiles_false = ["CN1N(C(=O)C=C1C)c1cccccx1",
+                    "CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
+                    "COC(=O[)]C1=CN=CC=N1",
+                    "1S/C2H7N3/c1-5-2(3)4"
+                    ]
 
     for smiles in smiles_true:
         assert is_valid_smiles(smiles), "Expected smiles is True."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from matchms.utils import mol_converter
-from matchms.utils import is_valid_inchi, is_valid_inchikey
+from matchms.utils import is_valid_inchi, is_valid_inchikey, is_valid_smiles
 
 
 def test_mol_converter_smiles_to_inchi():
@@ -55,3 +55,21 @@ def test_is_valid_inchi():
         assert is_valid_inchi(inchi), "Expected inchi is True."
     for inchi in inchi_false:
         assert not is_valid_inchi(inchi), "Expected inchi is False."
+
+
+def test_is_valid_smiles():
+    """Test if strings are correctly classified."""
+    smiles_true = ["CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
+                  "CN1N(C(=O)C=C1C)c1ccccc1",
+                  "COC(=O)C1=CN=CC=N1"
+                  ]
+    smiles_false = ["CN1N(C(=O)C=C1C)c1cccccx1",
+                   "CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
+                   "COC(=O[)]C1=CN=CC=N1",
+                   "1S/C2H7N3/c1-5-2(3)4"
+                   ]
+
+    for smiles in smiles_true:
+        assert is_valid_smiles(smiles), "Expected smiles is True."
+    for smiles in smiles_false:
+        assert not is_valid_smiles(smiles), "Expected smiles is False."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,26 @@
-from matchms.utils import is_valid_inchikey
+from matchms.utils import mol_converter
+from matchms.utils import is_valid_inchi, is_valid_inchikey
+
+
+def test_mol_converter_smiles_to_inchi():
+    """Test if smiles is correctly converted to inchi."""
+    mol_input = "C[Si](Cn1cncn1)(c1ccc(F)cc1)"
+    output_inchi = mol_converter(mol_input, "smiles", "inchi")
+    assert output_inchi == "InChI=1S/C10H11FN3Si/c1-15(8-14-7-12-6-13-14)10-4-2-9(11)3-5-10/h2-7H,8H2,1H3"
+
+
+def test_mol_converter_inchi_to_smiles():
+    """Test if inchi is correctly converted to smiles."""
+    mol_input = "InChI=1S/C10H11FN3Si/c1-15(8-14-7-12-6-13-14)10-4-2-9(11)3-5-10/h2-7H,8H2,1H3"
+    output_smiles = mol_converter(mol_input, "inchi", "smiles")
+    assert output_smiles == "C[Si](Cn1cncn1)=C1C=C[C](F)C=C1"
+
+
+def test_mol_converter_smiles_to_inchikey():
+    """Test if smiles is correctly converted to inchikey."""
+    mol_input = "C[Si](Cn1cncn1)(c1ccc(F)cc1)"
+    output_inchikey = mol_converter(mol_input, "smiles", "inchikey")
+    assert output_inchikey == "HULABQRTZQYJBQ-UHFFFAOYSA-N"
 
 
 def test_is_valid_inchikey():
@@ -16,3 +38,20 @@ def test_is_valid_inchikey():
         assert is_valid_inchikey(inchikey), "Expected inchikey is True."
     for inchikey in inchikeys_false:
         assert not is_valid_inchikey(inchikey), "Expected inchikey is False."
+
+
+def test_is_valid_inchi():
+    """Test if strings are correctly classified."""
+    inchi_true = ["InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
+                  '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"'
+                  ]
+    inchi_false = ["1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
+                   "InChI=1S/C2H7N3/c152(3)4/h1H3,(H4,3,4,5)",
+                   "InChI=C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
+                   "InChI=1S/C2H7N3/c1-5-2(3)"
+                   ]
+
+    for inchi in inchi_true:
+        assert is_valid_inchi(inchi), "Expected inchi is True."
+    for inchi in inchi_false:
+        assert not is_valid_inchi(inchi), "Expected inchi is False."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,13 +26,15 @@ def test_mol_converter_smiles_to_inchikey():
 def test_is_valid_inchikey():
     """Test if strings are correctly classified."""
     inchikeys_true = ["XYLJNLCSTIOKRM-UHFFFAOYSA-N"]
-    inchikeys_false = ["XYLJNLCSTIOKRM-UHFFFAOYSA",
-                       "XYLJNLCSTIOKRMRUHFFFAOYSASN",
-                       "XYLJNLCSTIOKR-MUHFFFAOYSA-N",
-                       "XYLJNLCSTIOKRM-UHFFFAOYSA-NN",
-                       "Brcc(NC2=NCN2)-ccc3nccnc1-3",
-                       "2YLJNLCSTIOKRM-UHFFFAOYSA-N",
-                       "XYLJNLCSTIOKRM-aaaaaaaaaa-a"]
+    inchikeys_false = [
+        "XYLJNLCSTIOKRM-UHFFFAOYSA",
+        "XYLJNLCSTIOKRMRUHFFFAOYSASN",
+        "XYLJNLCSTIOKR-MUHFFFAOYSA-N",
+        "XYLJNLCSTIOKRM-UHFFFAOYSA-NN",
+        "Brcc(NC2=NCN2)-ccc3nccnc1-3",
+        "2YLJNLCSTIOKRM-UHFFFAOYSA-N",
+        "XYLJNLCSTIOKRM-aaaaaaaaaa-a"
+        ]
 
     for inchikey in inchikeys_true:
         assert is_valid_inchikey(inchikey), "Expected inchikey is True."
@@ -42,14 +44,16 @@ def test_is_valid_inchikey():
 
 def test_is_valid_inchi():
     """Test if strings are correctly classified."""
-    inchi_true = ["InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-                  '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"'
-                  ]
-    inchi_false = ["1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-                   "InChI=1S/C2H7N3/c152(3)4/h1H3,(H4,3,4,5)",
-                   "InChI=C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-                   "InChI=1S/C2H7N3/c1-5-2(3)"
-                   ]
+    inchi_true = [
+        "InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
+        '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"'
+        ]
+    inchi_false = [
+        "1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
+        "InChI=1S/C2H7N3/c152(3)4/h1H3,(H4,3,4,5)",
+        "InChI=C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
+        "InChI=1S/C2H7N3/c1-5-2(3)"
+        ]
 
     for inchi in inchi_true:
         assert is_valid_inchi(inchi), "Expected inchi is True."
@@ -59,15 +63,17 @@ def test_is_valid_inchi():
 
 def test_is_valid_smiles():
     """Test if strings are correctly classified."""
-    smiles_true = [r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
-                   "CN1N(C(=O)C=C1C)c1ccccc1",
-                   "COC(=O)C1=CN=CC=N1"
-                   ]
-    smiles_false = ["CN1N(C(=O)C=C1C)c1cccccx1",
-                    r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
-                    "COC(=O[)]C1=CN=CC=N1",
-                    "1S/C2H7N3/c1-5-2(3)4"
-                    ]
+    smiles_true = [
+        r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
+        r"CN1N(C(=O)C=C1C)c1ccccc1",
+        r"COC(=O)C1=CN=CC=N1"
+        ]
+    smiles_false = [
+        r"CN1N(C(=O)C=C1C)c1cccccx1",
+        r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
+        r"COC(=O[)]C1=CN=CC=N1",
+        r"1S/C2H7N3/c1-5-2(3)4"
+        ]
 
     for smiles in smiles_true:
         assert is_valid_smiles(smiles), "Expected smiles is True."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,12 +59,12 @@ def test_is_valid_inchi():
 
 def test_is_valid_smiles():
     """Test if strings are correctly classified."""
-    smiles_true = ["CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
+    smiles_true = [r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
                    "CN1N(C(=O)C=C1C)c1ccccc1",
                    "COC(=O)C1=CN=CC=N1"
                    ]
     smiles_false = ["CN1N(C(=O)C=C1C)c1cccccx1",
-                    "CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
+                    r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
                     "COC(=O[)]C1=CN=CC=N1",
                     "1S/C2H7N3/c1-5-2(3)4"
                     ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,7 +33,8 @@ def test_is_valid_inchikey():
         "XYLJNLCSTIOKRM-UHFFFAOYSA-NN",
         "Brcc(NC2=NCN2)-ccc3nccnc1-3",
         "2YLJNLCSTIOKRM-UHFFFAOYSA-N",
-        "XYLJNLCSTIOKRM-aaaaaaaaaa-a"]
+        "XYLJNLCSTIOKRM-aaaaaaaaaa-a"
+    ]
 
     for inchikey in inchikeys_true:
         assert is_valid_inchikey(inchikey), "Expected inchikey is True."
@@ -45,12 +46,14 @@ def test_is_valid_inchi():
     """Test if strings are correctly classified."""
     inchi_true = [
         "InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-        '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"']
+        '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"'
+    ]
     inchi_false = [
         "1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
         "InChI=1S/C2H7N3/c152(3)4/h1H3,(H4,3,4,5)",
         "InChI=C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-        "InChI=1S/C2H7N3/c1-5-2(3)"]
+        "InChI=1S/C2H7N3/c1-5-2(3)"
+    ]
 
     for inchi in inchi_true:
         assert is_valid_inchi(inchi), "Expected inchi is True."
@@ -63,12 +66,14 @@ def test_is_valid_smiles():
     smiles_true = [
         r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
         r"CN1N(C(=O)C=C1C)c1ccccc1",
-        r"COC(=O)C1=CN=CC=N1"]
+        r"COC(=O)C1=CN=CC=N1"
+    ]
     smiles_false = [
         r"CN1N(C(=O)C=C1C)c1cccccx1",
         r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
         r"COC(=O[)]C1=CN=CC=N1",
-        r"1S/C2H7N3/c1-5-2(3)4"]
+        r"1S/C2H7N3/c1-5-2(3)4"
+    ]
 
     for smiles in smiles_true:
         assert is_valid_smiles(smiles), "Expected smiles is True."


### PR DESCRIPTION
- New implementation of ``mol_converter()`` function, now based on rdkit instead of openbabel.
- With this we can in principle dump ``openbabel`` which would close #129.
- Added tests for ``mol_converter()``, ``is_valid_smiles()``, and ``is_valid_inchi()``.

I ran both old and new implementation side-by-side on the actual data, converting >10,000 smiles and inchi and got virtually identical performance. It turns out that one of the reasons it was performing poorly before is that rdkit sometimes has trouble handling InChI in the format ``"InChI=..."`` Also there are some smiles that cannot be converted using rdkit (but could when using openabel). But those can be fixed later using lookups (or be ignored). 
Due to the license issue (#129) the new implementation hence seems favorable to me.

**QUESTION:** should we also remove openbabel from the environment in this PR?