### PR TITLE
Fix broken intensity order in add_losses

### DIFF
--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -1,8 +1,20 @@
+import numpy
 from ..Spikes import Spikes
+from ..typing import SpectrumType
 
 
-def add_losses(spectrum_in):
+def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -> SpectrumType:
+    """Derive losses based on precursor mass.
 
+    Args:
+    ----
+    spectrum_in: matchms.Spectrum
+        Input spectrum.
+    loss_mz_from: float
+        Minimum allowed m/z value for losses. Default is 0.0.
+    loss_mz_to: float
+        Maximum allowed m/z value for losses. Default is 1000.0.
+    """
     def precursor_mz_is_number():
         if isinstance(precursor_mz, int):
             return True
@@ -17,10 +29,15 @@ def add_losses(spectrum_in):
 
     precursor_mz = spectrum.get("precursor_mz")
     if precursor_mz is not None:
-        assert precursor_mz_is_number(), "Expected 'precursor_mz' to be a scalar number."
+        assert precursor_mz_is_number(), ("Expected 'precursor_mz' to be a scalar number.",
+                                          "Consider applying 'add_precursor_mz' filter first.")
         peaks_mz, peaks_intensities = spectrum.peaks
         losses_mz = (precursor_mz - peaks_mz)[::-1]
-        losses_intensities = peaks_intensities
-        spectrum.losses = Spikes(mz=losses_mz, intensities=losses_intensities)
+        losses_intensities = peaks_intensities[::-1]
+        # Add losses which are within given boundaries
+        keep_idx = numpy.where((losses_mz >= loss_mz_from)
+                               & (losses_mz <= loss_mz_to))[0]
+        spectrum.losses = Spikes(mz=losses_mz[keep_idx],
+                                 intensities=losses_intensities[keep_idx])
 
     return spectrum

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -35,7 +35,7 @@ def test_add_losses_with_precursor_mz_wrong_type():
     with pytest.raises(AssertionError) as msg:
         _ = add_losses(spectrum_in)
 
-    assert str(msg.value) == "Expected 'precursor_mz' to be a scalar number."
+    assert "Expected 'precursor_mz' to be a scalar number." in str(msg.value)
 
 
 def test_add_losses_returns_new_spectrum_instance():

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -11,7 +11,10 @@ def test_add_losses():
 
     spectrum = add_losses(spectrum_in)
 
-    assert numpy.allclose(spectrum.losses.mz, numpy.array([145, 245, 295, 345], "float"))
+    aim_mz = numpy.array([145, 245, 295, 345], "float")
+    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
+    aim_intensities = numpy.array([1000, 100, 200, 700], "float")
+    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
 
 
 def test_add_losses_without_precursor_mz():
@@ -48,3 +51,29 @@ def test_add_losses_with_input_none():
     spectrum_in = None
     spectrum = add_losses(spectrum_in)
     assert spectrum is None
+
+
+def test_add_losses_with_peakmz_larger_precursormz():
+    spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 450], dtype="float"),
+                           intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
+                           metadata={"precursor_mz": 445.0})
+
+    spectrum = add_losses(spectrum_in)
+
+    aim_mz = numpy.array([245, 295, 345], "float")
+    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
+    aim_intensities = numpy.array([100, 200, 700], "float")
+    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
+
+
+def test_add_losses_with_max_loss_mz_250():
+    spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 300], dtype="float"),
+                           intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
+                           metadata={"precursor_mz": 445.0})
+
+    spectrum = add_losses(spectrum_in, loss_mz_to=250)
+
+    aim_mz = numpy.array([145, 245], "float")
+    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
+    aim_intensities = numpy.array([1000, 100], "float")
+    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."


### PR DESCRIPTION
Addressing #226 
- fix intensity order in ``add_losses``
- add unit tests
- add _loss_mz_from_ and _loss_mz_to_ parameters to ``add_losses``