### PR TITLE
Adding CosineHungarian similarity score

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - gensim >=3.8.0
   - matplotlib
+  - numba >=0.47
   - numpy
   - pyteomics >=4.2
   - python >=3.7,<3.8

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -1,0 +1,98 @@
+import numba
+import numpy
+from scipy.optimize import linear_sum_assignment
+from matchms.typing import SpectrumType
+
+
+class CosineHungarian:
+    """Calculate cosine score between two spectra using the Hungarian algorithm.
+
+    This score is calculated by summing intensiy products of matching peaks between
+    two spectra (matching within set tolerance).
+    of two spectra.
+
+    Args:
+    ----
+    tolerance: float
+        Peaks will be considered a match when <= tolerance appart. Default is 0.1.
+    """
+    def __init__(self, tolerance=0.1):
+        self.tolerance = tolerance
+
+    def __call__(self, spectrum1: SpectrumType, spectrum2: SpectrumType) -> float:
+        """Calculate cosine score between two spectra.
+        Args:
+        ----
+        spectrum1: SpectrumType
+            Input spectrum 1.
+        spectrum2: SpectrumType
+            Input spectrum 2.
+        """
+        def get_normalized_peaks_arrays():
+            # Get peaks mz and intensities
+            spec1 = numpy.vstack((spectrum1.peaks.mz, spectrum1.peaks.intensities)).T
+            spec2 = numpy.vstack((spectrum2.peaks.mz, spectrum2.peaks.intensities)).T
+            # Normalize intensities
+            spec1[:, 1] = spec1[:, 1]/max(spec1[:, 1])
+            spec2[:, 1] = spec2[:, 1]/max(spec2[:, 1])
+            return spec1, spec2
+
+        def get_matching_pairs():
+            matching_pairs = find_pairs_numba(spec1, spec2, self.tolerance, shift=0.0)
+            matching_pairs = sorted(matching_pairs, key=lambda x: x[2], reverse=True)
+            return matching_pairs
+
+        def calc_score():
+            used_matches = []
+            list1 = list({x[0] for x in matching_pairs})
+            list2 = list({x[1] for x in matching_pairs})
+            matrix_size = (len(list1), len(list2))
+            matrix = numpy.ones(matrix_size)
+
+            if len(matching_pairs) > 0:
+                for match in matching_pairs:
+                    matrix[list1.index(match[0]), list2.index(match[1])] = 1 - match[2]
+                # Use hungarian agorithm to solve the linear sum assignment problem
+                row_ind, col_ind = linear_sum_assignment(matrix)
+                score = len(row_ind) - matrix[row_ind, col_ind].sum()
+                used_matches = [(list1[x], list2[y]) for (x, y) in zip(row_ind, col_ind)]
+                # Normalize score:
+                score = score/max(numpy.sum(spec1[:, 1]**2), numpy.sum(spec2[:, 1]**2))
+            else:
+                score = 0.0
+            return score, len(used_matches)
+
+        spec1, spec2 = get_normalized_peaks_arrays()
+        matching_pairs = get_matching_pairs()
+        return calc_score()
+
+
+@numba.njit
+def find_pairs_numba(spec1, spec2, tolerance, shift=0):
+    """Find matching pairs between two spectra.
+
+    Args
+    ----
+    spec1: numpy array
+        Spectrum peaks and intensities as numpy array.
+    spec2: numpy array
+        Spectrum peaks and intensities as numpy array.
+    tolerance : float
+        Peaks will be considered a match when <= tolerance appart.
+    shift : float, optional
+        Shift spectra peaks by shift. The default is 0.
+
+    Returns
+    -------
+    matching_pairs : list
+        List of found matching peaks.
+    """
+    matching_pairs = []
+
+    for idx in range(len(spec1)):
+        intensity = spec1[idx, 1]
+        matches = numpy.where((numpy.abs(spec2[:, 0] - spec1[idx, 0] + shift) <= tolerance))[0]
+        for match in matches:
+            matching_pairs.append((idx, match, intensity*spec2[match][1]))
+
+    return matching_pairs

--- a/matchms/similarity/__init__.py
+++ b/matchms/similarity/__init__.py
@@ -1,9 +1,11 @@
 """similarity module"""
 from .CosineGreedy import CosineGreedy
+from .CosineHungarian import CosineHungarian
 from .IntersectMz import IntersectMz
 
 
 __all__ = [
     "CosineGreedy",
+    "CosineHungarian",
     "IntersectMz"
 ]


### PR DESCRIPTION
So far we implemented a greedy version of the cosine score (which is often used because it is faster and gives the same results in 99,9% (that's a guess) of the actual cases.

The Hungarian algorithm would be the fully correct solution of the optimization problem, so it is nice to have it as well.

Here an example where the greedy scores would fail:
```python
from matchms import Spectrum
from matchms.filtering import normalize_intensities
from matchms.similarity import CosineGreedy, CosineGreedyNumba, CosineHungarian

test_spectrum1 = Spectrum(mz=np.array([100.005, 100.016]),
                         intensities=np.array([1.0, 0.9]),
                         metadata={})

test_spectrum2 = Spectrum(mz=np.array([100.005, 100.01]),
                         intensities=np.array([0.9, 1.0]),
                         metadata={})

test_spectrum1 = normalize_intensities(test_spectrum1)
test_spectrum2 = normalize_intensities(test_spectrum2)

similarity_measure = CosineGreedyNumba(tolerance=0.01)
print(similarity_measure(test_spectrum1, test_spectrum2))

similarity_measure = CosineGreedy(tolerance=0.01)
print(similarity_measure(test_spectrum1, test_spectrum2))

similarity_measure = CosineHungarian(tolerance=0.01)
print(similarity_measure(test_spectrum1, test_spectrum2))
```
``(0.5524861878453039, 1)``
``(0.5524861878453039, 1)``
``(0.994475138121547, 2)``